### PR TITLE
Normalize file extension validation

### DIFF
--- a/backend/open_webui/test/apps/webui/routers/test_files.py
+++ b/backend/open_webui/test/apps/webui/routers/test_files.py
@@ -1,0 +1,17 @@
+import pytest
+from fastapi import HTTPException, status
+
+from open_webui.routers.files import _validate_file_extension
+
+
+class TestFileExtensionValidation:
+    def test_allows_case_insensitive_matches(self):
+        _validate_file_extension("PDF", ["pdf", "doc"])
+        _validate_file_extension("pdf", ["PDF", "DOC"])
+
+    def test_rejects_disallowed_extensions(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_file_extension("exe", ["pdf", "doc"])
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "File type exe is not allowed" in exc_info.value.detail


### PR DESCRIPTION
## Summary
- normalize uploaded file extensions and configured allowed extensions before validation without mutating persistent config
- add unit tests that cover case-insensitive acceptance and rejection of disallowed file extensions

## Testing
- PYTHONPATH=backend pytest backend/open_webui/test/apps/webui/routers/test_files.py

------
https://chatgpt.com/codex/tasks/task_e_68ca80af07188331a05700befad37b40