### PR TITLE
Expose allowed file extensions in config

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1764,6 +1764,7 @@ async def get_app_config(request: Request):
                 "file": {
                     "max_size": app.state.config.FILE_MAX_SIZE,
                     "max_count": app.state.config.FILE_MAX_COUNT,
+                    "allowed_extensions": app.state.config.ALLOWED_FILE_EXTENSIONS,
                     "image_compression": {
                         "width": app.state.config.FILE_IMAGE_COMPRESSION_WIDTH,
                         "height": app.state.config.FILE_IMAGE_COMPRESSION_HEIGHT,

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -244,6 +244,7 @@ type Config = {
 	default_locale: string;
 	default_models: string;
 	default_prompt_suggestions: PromptSuggestion[];
+	user_count?: number;
 	features: {
 		auth: boolean;
 		auth_trusted_header: boolean;
@@ -266,9 +267,43 @@ type Config = {
 			[key: string]: string;
 		};
 	};
+	code?: {
+		engine?: string | null;
+	};
+	audio?: {
+		tts?: {
+			engine?: string | null;
+			voice?: string | null;
+			split_on?: string | null;
+		};
+		stt?: {
+			engine?: string | null;
+		};
+	};
+	file?: {
+		max_size?: number | null;
+		max_count?: number | null;
+		allowed_extensions?: string[];
+		image_compression?: {
+			width?: number | null;
+			height?: number | null;
+		};
+	};
+	permissions?: Record<string, unknown>;
+	google_drive?: {
+		client_id?: string;
+		api_key?: string;
+	};
+	onedrive?: {
+		client_id?: string;
+		sharepoint_url?: string;
+		sharepoint_tenant_id?: string;
+	};
 	ui?: {
 		pending_user_overlay_title?: string;
 		pending_user_overlay_description?: string;
+		pending_user_overlay_content?: string;
+		response_watermark?: string;
 	};
 };
 


### PR DESCRIPTION
## Summary
- include the backend's allowed file extensions in the `/api/config` file metadata response
- expand the frontend `Config` type so the new `file.allowed_extensions` data (and related metadata) are available to the UI

## Testing
- npm install *(fails: dependency conflict with @tiptap/extension-bubble-menu)*
- npm install --legacy-peer-deps *(fails: onnxruntime download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca804a99e883318523c87e10959fa0